### PR TITLE
Fix Int64._parseRadix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.10
+
+* Fix `Int64` parsing to throw `FormatException` on an empty string or single
+  minus sign. Previous incorrect behaviour was to throw a `RangeError` or
+  silently return zero.
+
 ## 0.10.9
 
 * Add `Int64.toStringUnsigned()` and `Int64.toRadixStringUnsigned()` functions.

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -64,7 +64,8 @@ class Int64 implements IntX {
       i++;
     }
 
-    if (i >= s.length) {
+    // TODO(https://github.com/dart-lang/sdk/issues/38728): use (i >= s.length).
+    if (!(i < s.length)) {
       throw FormatException("No digits in '$s'");
     }
 

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -64,8 +64,9 @@ class Int64 implements IntX {
       i++;
     }
 
-    // TODO(https://github.com/dart-lang/sdk/issues/38728): use (i >= s.length).
-    if (!(i < s.length)) {
+    // TODO(https://github.com/dart-lang/sdk/issues/38728). Remove this ignore.
+    // ignore: invariant_booleans
+    if (i >= s.length) {
       throw FormatException("No digits in '$s'");
     }
 

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -64,9 +64,9 @@ class Int64 implements IntX {
       i++;
     }
 
-    // TODO(https://github.com/dart-lang/sdk/issues/38728). Remove this ignore.
-    // ignore: invariant_booleans
-    if (i >= s.length) {
+    // TODO(https://github.com/dart-lang/sdk/issues/38728). Replace with "if (i
+    // >= s.length)".
+    if (!(i < s.length)) {
       throw FormatException("No digits in '$s'");
     }
 

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -59,10 +59,15 @@ class Int64 implements IntX {
   static Int64 _parseRadix(String s, int radix) {
     int i = 0;
     bool negative = false;
-    if (s[0] == '-') {
+    if (i < s.length && s[0] == '-') {
       negative = true;
       i++;
     }
+
+    if (i >= s.length) {
+      throw FormatException("No digits in '$s'");
+    }
+
     int d0 = 0, d1 = 0, d2 = 0; //  low, middle, high components.
     for (; i < s.length; i++) {
       int c = s.codeUnitAt(i);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fixnum
-version: 0.10.9
+version: 0.10.10
 
 description: Library for 32- and 64-bit signed fixed-width integers.
 author: Dart Team <misc@dartlang.org>

--- a/test/int64_test.dart
+++ b/test/int64_test.dart
@@ -729,7 +729,7 @@ void main() {
     expect(-(Int64.MIN_VALUE + Int64(1)), Int64.MAX_VALUE);
   });
 
-  test("misc", () {
+  test("negation", () {
     check(int n) {
       // Sign change should commute with conversion.
       expect(-Int64(-n), Int64(n));

--- a/test/int64_test.dart
+++ b/test/int64_test.dart
@@ -729,7 +729,7 @@ void main() {
     expect(-(Int64.MIN_VALUE + Int64(1)), Int64.MAX_VALUE);
   });
 
-  test("", () {
+  test("misc", () {
     check(int n) {
       // Sign change should commute with conversion.
       expect(-Int64(-n), Int64(n));
@@ -763,6 +763,8 @@ void main() {
       checkInt(-4294967296);
       expect(() => Int64.parseRadix('xyzzy', -1), throwsArgumentError);
       expect(() => Int64.parseRadix('plugh', 10), throwsFormatException);
+      expect(() => Int64.parseRadix('', 10), throwsFormatException);
+      expect(() => Int64.parseRadix('-', 10), throwsFormatException);
     });
 
     test("parseHex", () {
@@ -783,6 +785,8 @@ void main() {
       checkHex('FFFFFFFFFFF', 0xfff, 0xffffffff);
       checkHex('FFFFFFFFFFFFFFFE', 0xffffffff, 0xfffffffe);
       checkHex('FFFFFFFFFFFFFFFF', 0xffffffff, 0xffffffff);
+      expect(() => Int64.parseHex(''), throwsFormatException);
+      expect(() => Int64.parseHex('-'), throwsFormatException);
     });
 
     test("parseRadix", () {


### PR DESCRIPTION
Fixes the following:

 - `Int64.parse('')` would throw a `RangeError` instead of a `FormatException`.
 - `Int64.parse('-')` would return `Int64(0)` instead of throwing `FormatException`.
