### PR TITLE
migrate fixnum to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0-dev
+
+* Migrate to null safety.
+  * This is meant to be mostly non-breaking, for opted in users runtime errors
+    will be promoted to static errors. For non-opted in users the runtime
+    errors are still present in their original form.
+
 ## 0.10.11
 
 * Update minimum SDK constraint to version 2.1.1.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,9 @@ include: package:pedantic/analysis_options.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
+  enable-experiment:
+    - non-nullable
+
 linter:
   rules:
     - avoid_function_literals_in_foreach_calls

--- a/lib/src/int32.dart
+++ b/lib/src/int32.dart
@@ -122,7 +122,7 @@ class Int32 implements IntX {
 
   // Returns the [int] representation of the specified value. Throws
   // [ArgumentError] for non-integer arguments.
-  int _toInt(val) {
+  int _toInt(Object val) {
     if (val is Int32) {
       return val._i;
     } else if (val is int) {
@@ -146,7 +146,7 @@ class Int32 implements IntX {
   // Int32 % Int64 => Int32
 
   @override
-  IntX operator +(other) {
+  IntX operator +(Object other) {
     if (other is Int64) {
       return toInt64() + other;
     }
@@ -154,7 +154,7 @@ class Int32 implements IntX {
   }
 
   @override
-  IntX operator -(other) {
+  IntX operator -(Object other) {
     if (other is Int64) {
       return toInt64() - other;
     }
@@ -165,7 +165,7 @@ class Int32 implements IntX {
   Int32 operator -() => Int32(-_i);
 
   @override
-  IntX operator *(other) {
+  IntX operator *(Object other) {
     if (other is Int64) {
       return toInt64() * other;
     }
@@ -174,7 +174,7 @@ class Int32 implements IntX {
   }
 
   @override
-  Int32 operator %(other) {
+  Int32 operator %(Object other) {
     if (other is Int64) {
       // Result will be Int32
       return (toInt64() % other).toInt32();
@@ -183,7 +183,7 @@ class Int32 implements IntX {
   }
 
   @override
-  Int32 operator ~/(other) {
+  Int32 operator ~/(Object other) {
     if (other is Int64) {
       return (toInt64() ~/ other).toInt32();
     }
@@ -191,7 +191,7 @@ class Int32 implements IntX {
   }
 
   @override
-  Int32 remainder(other) {
+  Int32 remainder(Object other) {
     if (other is Int64) {
       var t = toInt64();
       return (t - (t ~/ other) * other).toInt32();
@@ -200,7 +200,7 @@ class Int32 implements IntX {
   }
 
   @override
-  Int32 operator &(other) {
+  Int32 operator &(Object other) {
     if (other is Int64) {
       return (toInt64() & other).toInt32();
     }
@@ -208,7 +208,7 @@ class Int32 implements IntX {
   }
 
   @override
-  Int32 operator |(other) {
+  Int32 operator |(Object other) {
     if (other is Int64) {
       return (toInt64() | other).toInt32();
     }
@@ -216,7 +216,7 @@ class Int32 implements IntX {
   }
 
   @override
-  Int32 operator ^(other) {
+  Int32 operator ^(Object other) {
     if (other is Int64) {
       return (toInt64() ^ other).toInt32();
     }
@@ -274,7 +274,7 @@ class Int32 implements IntX {
   /// Returns [:true:] if this [Int32] has the same numeric value as the
   /// given object.  The argument may be an [int] or an [IntX].
   @override
-  bool operator ==(other) {
+  bool operator ==(Object? other) {
     if (other is Int32) {
       return _i == other._i;
     } else if (other is Int64) {
@@ -286,15 +286,16 @@ class Int32 implements IntX {
   }
 
   @override
-  int compareTo(other) {
+  int compareTo(Object? other) {
     if (other is Int64) {
       return toInt64().compareTo(other);
     }
+    if (other == null) throw ArgumentError(null);
     return _i.compareTo(_toInt(other));
   }
 
   @override
-  bool operator <(other) {
+  bool operator <(Object other) {
     if (other is Int64) {
       return toInt64() < other;
     }
@@ -302,7 +303,7 @@ class Int32 implements IntX {
   }
 
   @override
-  bool operator <=(other) {
+  bool operator <=(Object other) {
     if (other is Int64) {
       return toInt64() <= other;
     }
@@ -310,7 +311,7 @@ class Int32 implements IntX {
   }
 
   @override
-  bool operator >(other) {
+  bool operator >(Object other) {
     if (other is Int64) {
       return toInt64() > other;
     }
@@ -318,7 +319,7 @@ class Int32 implements IntX {
   }
 
   @override
-  bool operator >=(other) {
+  bool operator >=(Object other) {
     if (other is Int64) {
       return toInt64() >= other;
     }
@@ -353,7 +354,7 @@ class Int32 implements IntX {
   Int32 abs() => _i < 0 ? Int32(-_i) : this;
 
   @override
-  Int32 clamp(lowerLimit, upperLimit) {
+  Int32 clamp(Object lowerLimit, Object upperLimit) {
     if (this < lowerLimit) {
       if (lowerLimit is IntX) return lowerLimit.toInt32();
       if (lowerLimit is int) return Int32(lowerLimit);
@@ -385,14 +386,12 @@ class Int32 implements IntX {
   }
 
   @override
-  List<int> toBytes() {
-    var result = List<int>(4);
-    result[0] = _i & 0xff;
-    result[1] = (_i >> 8) & 0xff;
-    result[2] = (_i >> 16) & 0xff;
-    result[3] = (_i >> 24) & 0xff;
-    return result;
-  }
+  List<int> toBytes() => [
+        _i & 0xff,
+        (_i >> 8) & 0xff,
+        (_i >> 16) & 0xff,
+        (_i >> 24) & 0xff,
+      ];
 
   @override
   double toDouble() => _i.toDouble();

--- a/lib/src/int32.dart
+++ b/lib/src/int32.dart
@@ -386,12 +386,14 @@ class Int32 implements IntX {
   }
 
   @override
-  List<int> toBytes() => [
-        _i & 0xff,
-        (_i >> 8) & 0xff,
-        (_i >> 16) & 0xff,
-        (_i >> 24) & 0xff,
-      ];
+  List<int> toBytes() {
+    var result = List<int>.filled(4, 0);
+    result[0] = _i & 0xff;
+    result[1] = (_i >> 8) & 0xff;
+    result[2] = (_i >> 16) & 0xff;
+    result[3] = (_i >> 24) & 0xff;
+    return result;
+  }
 
   @override
   double toDouble() => _i.toDouble();

--- a/lib/src/int32.dart
+++ b/lib/src/int32.dart
@@ -274,7 +274,7 @@ class Int32 implements IntX {
   /// Returns [:true:] if this [Int32] has the same numeric value as the
   /// given object.  The argument may be an [int] or an [IntX].
   @override
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     if (other is Int32) {
       return _i == other._i;
     } else if (other is Int64) {
@@ -286,11 +286,10 @@ class Int32 implements IntX {
   }
 
   @override
-  int compareTo(Object? other) {
+  int compareTo(Object other) {
     if (other is Int64) {
       return toInt64().compareTo(other);
     }
-    if (other == null) throw ArgumentError(null);
     return _i.compareTo(_toInt(other));
   }
 

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -633,16 +633,18 @@ class Int64 implements IntX {
   }
 
   @override
-  List<int> toBytes() => [
-        _l & 0xff,
-        (_l >> 8) & 0xff,
-        ((_m << 6) & 0xfc) | ((_l >> 16) & 0x3f),
-        (_m >> 2) & 0xff,
-        (_m >> 10) & 0xff,
-        ((_h << 4) & 0xf0) | ((_m >> 18) & 0xf),
-        (_h >> 4) & 0xff,
-        (_h >> 12) & 0xff,
-      ];
+  List<int> toBytes() {
+    var result = List<int>.filled(8, 0);
+    result[0] = _l & 0xff;
+    result[1] = (_l >> 8) & 0xff;
+    result[2] = ((_m << 6) & 0xfc) | ((_l >> 16) & 0x3f);
+    result[3] = (_m >> 2) & 0xff;
+    result[4] = (_m >> 10) & 0xff;
+    result[5] = ((_h << 4) & 0xf0) | ((_m >> 18) & 0xf);
+    result[6] = (_h >> 4) & 0xff;
+    result[7] = (_h >> 12) & 0xff;
+    return result;
+  }
 
   @override
   double toDouble() => toInt().toDouble();

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -462,10 +462,7 @@ class Int64 implements IntX {
   }
 
   @override
-  int compareTo(Object? other) {
-    if (other == null) throw ArgumentError(null);
-    return _compareTo(other);
-  }
+  int compareTo(Object other) => _compareTo(other);
 
   int _compareTo(Object other) {
     Int64 o = _promote(other);

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -198,7 +198,7 @@ class Int64 implements IntX {
   }
 
   @override
-  Int64 operator +(other) {
+  Int64 operator +(Object other) {
     Int64 o = _promote(other);
     int sum0 = _l + o._l;
     int sum1 = _m + o._m + (sum0 >> _BITS);
@@ -207,7 +207,7 @@ class Int64 implements IntX {
   }
 
   @override
-  Int64 operator -(other) {
+  Int64 operator -(Object other) {
     Int64 o = _promote(other);
     return _sub(_l, _m, _h, o._l, o._m, o._h);
   }
@@ -216,7 +216,7 @@ class Int64 implements IntX {
   Int64 operator -() => _negate(_l, _m, _h);
 
   @override
-  Int64 operator *(other) {
+  Int64 operator *(Object other) {
     Int64 o = _promote(other);
 
     // Grab 13-bit chunks.
@@ -298,16 +298,16 @@ class Int64 implements IntX {
   }
 
   @override
-  Int64 operator %(other) => _divide(this, other, _RETURN_MOD);
+  Int64 operator %(Object other) => _divide(this, other, _RETURN_MOD);
 
   @override
-  Int64 operator ~/(other) => _divide(this, other, _RETURN_DIV);
+  Int64 operator ~/(Object other) => _divide(this, other, _RETURN_DIV);
 
   @override
-  Int64 remainder(other) => _divide(this, other, _RETURN_REM);
+  Int64 remainder(Object other) => _divide(this, other, _RETURN_REM);
 
   @override
-  Int64 operator &(other) {
+  Int64 operator &(Object other) {
     Int64 o = _promote(other);
     int a0 = _l & o._l;
     int a1 = _m & o._m;
@@ -316,7 +316,7 @@ class Int64 implements IntX {
   }
 
   @override
-  Int64 operator |(other) {
+  Int64 operator |(Object other) {
     Int64 o = _promote(other);
     int a0 = _l | o._l;
     int a1 = _m | o._m;
@@ -325,7 +325,7 @@ class Int64 implements IntX {
   }
 
   @override
-  Int64 operator ^(other) {
+  Int64 operator ^(Object other) {
     Int64 o = _promote(other);
     int a0 = _l ^ o._l;
     int a1 = _m ^ o._m;
@@ -442,8 +442,8 @@ class Int64 implements IntX {
   /// Returns [:true:] if this [Int64] has the same numeric value as the
   /// given object.  The argument may be an [int] or an [IntX].
   @override
-  bool operator ==(other) {
-    Int64 o;
+  bool operator ==(Object other) {
+    Int64? o;
     if (other is Int64) {
       o = other;
     } else if (other is int) {
@@ -462,9 +462,12 @@ class Int64 implements IntX {
   }
 
   @override
-  int compareTo(other) => _compareTo(other);
+  int compareTo(Object? other) {
+    if (other == null) throw ArgumentError(null);
+    return _compareTo(other);
+  }
 
-  int _compareTo(other) {
+  int _compareTo(Object other) {
     Int64 o = _promote(other);
     int signa = _h >> (_BITS2 - 1);
     int signb = o._h >> (_BITS2 - 1);
@@ -490,16 +493,16 @@ class Int64 implements IntX {
   }
 
   @override
-  bool operator <(other) => _compareTo(other) < 0;
+  bool operator <(Object other) => _compareTo(other) < 0;
 
   @override
-  bool operator <=(other) => _compareTo(other) <= 0;
+  bool operator <=(Object other) => _compareTo(other) <= 0;
 
   @override
-  bool operator >(other) => _compareTo(other) > 0;
+  bool operator >(Object other) => _compareTo(other) > 0;
 
   @override
-  bool operator >=(other) => _compareTo(other) >= 0;
+  bool operator >=(Object other) => _compareTo(other) >= 0;
 
   @override
   bool get isEven => (_l & 0x1) == 0;
@@ -549,7 +552,7 @@ class Int64 implements IntX {
   }
 
   @override
-  Int64 clamp(lowerLimit, upperLimit) {
+  Int64 clamp(Object lowerLimit, Object upperLimit) {
     Int64 lower = _promote(lowerLimit);
     Int64 upper = _promote(upperLimit);
     if (this < lower) return lower;
@@ -630,18 +633,16 @@ class Int64 implements IntX {
   }
 
   @override
-  List<int> toBytes() {
-    List<int> result = List<int>(8);
-    result[0] = _l & 0xff;
-    result[1] = (_l >> 8) & 0xff;
-    result[2] = ((_m << 6) & 0xfc) | ((_l >> 16) & 0x3f);
-    result[3] = (_m >> 2) & 0xff;
-    result[4] = (_m >> 10) & 0xff;
-    result[5] = ((_h << 4) & 0xf0) | ((_m >> 18) & 0xf);
-    result[6] = (_h >> 4) & 0xff;
-    result[7] = (_h >> 12) & 0xff;
-    return result;
-  }
+  List<int> toBytes() => [
+        _l & 0xff,
+        (_l >> 8) & 0xff,
+        ((_m << 6) & 0xfc) | ((_l >> 16) & 0x3f),
+        (_m >> 2) & 0xff,
+        (_m >> 10) & 0xff,
+        ((_h << 4) & 0xf0) | ((_m >> 18) & 0xf),
+        (_h >> 4) & 0xff,
+        (_h >> 12) & 0xff,
+      ];
 
   @override
   double toDouble() => toInt().toDouble();

--- a/lib/src/intx.dart
+++ b/lib/src/intx.dart
@@ -7,10 +7,10 @@ part of fixnum;
 /// A fixed-precision integer.
 abstract class IntX implements Comparable<dynamic> {
   /// Addition operator.
-  IntX operator +(other);
+  IntX operator +(Object other);
 
   /// Subtraction operator.
-  IntX operator -(other);
+  IntX operator -(Object other);
 
   /// Negate operator.
   ///
@@ -18,30 +18,30 @@ abstract class IntX implements Comparable<dynamic> {
   IntX operator -();
 
   /// Multiplication operator.
-  IntX operator *(other);
+  IntX operator *(Object other);
 
   /// Euclidean modulo operator.
   ///
   /// Returns the remainder of the euclidean division. The euclidean division
   /// of two integers `a` and `b` yields two integers `q` and `r` such that
   /// `a == b * q + r` and `0 <= r < a.abs()`.
-  IntX operator %(other);
+  IntX operator %(Object other);
 
   /// Truncating division operator.
-  IntX operator ~/(other);
+  IntX operator ~/(Object other);
 
   /// Returns the remainder of the truncating division of this integer by
   /// [other].
-  IntX remainder(other);
+  IntX remainder(Object other);
 
   /// Bitwise and operator.
-  IntX operator &(other);
+  IntX operator &(Object other);
 
   /// Bitwise or operator.
-  IntX operator |(other);
+  IntX operator |(Object other);
 
   /// Bitwise xor operator.
-  IntX operator ^(other);
+  IntX operator ^(Object other);
 
   /// Bitwise negate operator.
   IntX operator ~();
@@ -66,24 +66,24 @@ abstract class IntX implements Comparable<dynamic> {
   IntX shiftRightUnsigned(int shiftAmount);
 
   @override
-  int compareTo(other);
+  int compareTo(Object? other);
 
   /// Returns `true` if and only if [other] is an int or IntX equal in
   /// value to this integer.
   @override
-  bool operator ==(other);
+  bool operator ==(Object other);
 
   /// Relational less than operator.
-  bool operator <(other);
+  bool operator <(Object other);
 
   /// Relational less than or equal to operator.
-  bool operator <=(other);
+  bool operator <=(Object other);
 
   /// Relational greater than operator.
-  bool operator >(other);
+  bool operator >(Object other);
 
   /// Relational greater than or equal to operator.
-  bool operator >=(other);
+  bool operator >=(Object other);
 
   /// Returns `true` if and only if this integer is even.
   bool get isEven;
@@ -112,7 +112,7 @@ abstract class IntX implements Comparable<dynamic> {
   IntX abs();
 
   /// Clamps this integer to be in the range [lowerLimit] - [upperLimit].
-  IntX clamp(lowerLimit, upperLimit);
+  IntX clamp(Object lowerLimit, Object upperLimit);
 
   /// Returns the minimum number of bits required to store this integer.
   ///

--- a/lib/src/intx.dart
+++ b/lib/src/intx.dart
@@ -5,7 +5,7 @@
 part of fixnum;
 
 /// A fixed-precision integer.
-abstract class IntX implements Comparable<dynamic> {
+abstract class IntX implements Comparable<Object> {
   /// Addition operator.
   IntX operator +(Object other);
 
@@ -66,7 +66,7 @@ abstract class IntX implements Comparable<dynamic> {
   IntX shiftRightUnsigned(int shiftAmount);
 
   @override
-  int compareTo(Object? other);
+  int compareTo(Object other);
 
   /// Returns `true` if and only if [other] is an int or IntX equal in
   /// value to this integer.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,87 @@
 name: fixnum
-version: 0.10.12-dev
+version: 1.0.0-dev
 
 description: Library for 32- and 64-bit signed fixed-width integers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/fixnum
 
 environment:
-  sdk: '>=2.1.1 <3.0.0'
+  sdk: '>=2.9.0-dev <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.8.0
   test: ^1.2.0
+
+dependency_overrides:
+  test:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test
+  test_api:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test_api
+  test_core:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test_core
+  async:
+    git:
+      url: git://github.com/dart-lang/async.git
+      ref: null_safety
+  boolean_selector:
+    git:
+      url: git://github.com/dart-lang/boolean_selector.git
+      ref: null_safety
+  charcode:
+    git:
+      url: git://github.com/dart-lang/charcode.git
+      ref: null_safety
+  collection:
+    git:
+      url: git://github.com/dart-lang/collection.git
+      ref: null_safety
+  matcher:
+    git:
+      url: git://github.com/dart-lang/matcher.git
+      ref: null_safety
+  meta:
+    git:
+      url: git://github.com/dart-lang/sdk.git
+      ref: null_safety-pkgs
+      path: pkg/meta
+  path:
+    git:
+      url: git://github.com/dart-lang/path.git
+      ref: null_safety
+  pedantic:
+    git:
+      url: git://github.com/dart-lang/pedantic.git
+      ref: null_safety
+  pool:
+    git:
+      url: git://github.com/dart-lang/pool.git
+      ref: null_safety
+  source_span:
+    git:
+      url: git://github.com/dart-lang/source_span.git
+      ref: null_safety
+  stack_trace:
+    git:
+      url: git://github.com/dart-lang/stack_trace.git
+      ref: null_safety
+  stream_channel:
+    git:
+      url: git://github.com/dart-lang/stream_channel.git
+      ref: null_safety
+  string_scanner:
+    git:
+      url: git://github.com/dart-lang/string_scanner.git
+      ref: null_safety
+  term_glyph:
+    git:
+      url: git://github.com/dart-lang/term_glyph.git
+      ref: null_safety

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/fixnum
 
 environment:
-  sdk: '>=2.9.0-dev <3.0.0'
+  sdk: '>=2.9.0-1 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/test/int32_test.dart
+++ b/test/int32_test.dart
@@ -62,7 +62,6 @@ void main() {
       expect(n3 + n4, Int32(-11110));
       expect(n3 + Int64(1), Int64(-1233));
       expect(Int32.MAX_VALUE + 1, Int32.MIN_VALUE);
-      expect(() => Int32(17) + null, throwsArgumentError);
     });
 
     test('-', () {
@@ -71,7 +70,6 @@ void main() {
       expect(n3 - n4, Int32(8642));
       expect(n3 - Int64(1), Int64(-1235));
       expect(Int32.MIN_VALUE - 1, Int32.MAX_VALUE);
-      expect(() => Int32(17) - null, throwsArgumentError);
     });
 
     test('unary -', () {
@@ -89,7 +87,6 @@ void main() {
       expect(Int32(0x12345678) * Int64(0x22222222),
           Int64.fromInts(0x026D60DC, 0xCA5F6BF0));
       expect((Int32(123456789) * 987654321), Int32(-67153019));
-      expect(() => Int32(17) * null, throwsArgumentError);
     });
 
     test('~/', () {
@@ -104,13 +101,11 @@ void main() {
           // on the VM: IntegerDivisionByZeroException
           throwsA(anyOf(const TypeMatcher<IntegerDivisionByZeroException>(),
               isUnsupportedError)));
-      expect(() => Int32(17) ~/ null, throwsArgumentError);
     });
 
     test('%', () {
       expect(Int32(0x12345678) % Int32(0x22), Int32(0x12345678 % 0x22));
       expect(Int32(0x12345678) % Int64(0x22), Int32(0x12345678 % 0x22));
-      expect(() => Int32(17) % null, throwsArgumentError);
     });
 
     test('remainder', () {
@@ -124,7 +119,6 @@ void main() {
           Int32(-0x12345678.remainder(0x22) as int));
       expect(Int32(0x12345678).remainder(Int64(0x22)),
           Int32(0x12345678.remainder(0x22) as int));
-      expect(() => Int32(17).remainder(null), throwsArgumentError);
     });
 
     test('abs', () {
@@ -197,7 +191,6 @@ void main() {
       expect(Int32(17) < Int64(16), false);
       expect(Int32.MIN_VALUE < Int32.MAX_VALUE, true);
       expect(Int32.MAX_VALUE < Int32.MIN_VALUE, false);
-      expect(() => Int32(17) < null, throwsArgumentError);
     });
 
     test('<=', () {
@@ -209,7 +202,6 @@ void main() {
       expect(Int32(17) <= Int64(16), false);
       expect(Int32.MIN_VALUE <= Int32.MAX_VALUE, true);
       expect(Int32.MAX_VALUE <= Int32.MIN_VALUE, false);
-      expect(() => Int32(17) <= null, throwsArgumentError);
     });
 
     test('==', () {
@@ -236,7 +228,6 @@ void main() {
       expect(Int32(17) >= Int64(16), true);
       expect(Int32.MIN_VALUE >= Int32.MAX_VALUE, false);
       expect(Int32.MAX_VALUE >= Int32.MIN_VALUE, true);
-      expect(() => Int32(17) >= null, throwsArgumentError);
     });
 
     test('>', () {
@@ -248,7 +239,6 @@ void main() {
       expect(Int32(17) > Int64(16), true);
       expect(Int32.MIN_VALUE > Int32.MAX_VALUE, false);
       expect(Int32.MAX_VALUE > Int32.MIN_VALUE, true);
-      expect(() => Int32(17) > null, throwsArgumentError);
     });
   });
 
@@ -258,7 +248,6 @@ void main() {
           Int32(0x12345678 & 0x22222222));
       expect(Int32(0x12345678) & Int64(0x22222222),
           Int64(0x12345678 & 0x22222222));
-      expect(() => Int32(17) & null, throwsArgumentError);
     });
 
     test('|', () {
@@ -266,7 +255,6 @@ void main() {
           Int32(0x12345678 | 0x22222222));
       expect(Int32(0x12345678) | Int64(0x22222222),
           Int64(0x12345678 | 0x22222222));
-      expect(() => Int32(17) | null, throwsArgumentError);
     });
 
     test('^', () {
@@ -274,7 +262,6 @@ void main() {
           Int32(0x12345678 ^ 0x22222222));
       expect(Int32(0x12345678) ^ Int64(0x22222222),
           Int64(0x12345678 ^ 0x22222222));
-      expect(() => Int32(17) ^ null, throwsArgumentError);
     });
 
     test('~', () {
@@ -289,7 +276,6 @@ void main() {
       expect(Int32(0x12345678) << 32, Int32.ZERO);
       expect(Int32(0x12345678) << 33, Int32.ZERO);
       expect(() => Int32(17) << -1, throwsArgumentError);
-      expect(() => Int32(17) << null, throwsNoSuchMethodError);
     });
 
     test('>>', () {
@@ -299,7 +285,6 @@ void main() {
       expect(Int32(-42) >> 32, Int32(-1));
       expect(Int32(-42) >> 33, Int32(-1));
       expect(() => Int32(17) >> -1, throwsArgumentError);
-      expect(() => Int32(17) >> null, throwsNoSuchMethodError);
     });
 
     test('shiftRightUnsigned', () {
@@ -309,8 +294,6 @@ void main() {
       expect(Int32(-42).shiftRightUnsigned(32), Int32.ZERO);
       expect(Int32(-42).shiftRightUnsigned(33), Int32.ZERO);
       expect(() => (Int32(17).shiftRightUnsigned(-1)), throwsArgumentError);
-      expect(
-          () => (Int32(17).shiftRightUnsigned(null)), throwsNoSuchMethodError);
     });
   });
 

--- a/test/int64_test.dart
+++ b/test/int64_test.dart
@@ -46,7 +46,10 @@ void main() {
     Matcher throwsArgumentErrorMentioning(String substring) =>
         throwsA((e) => e is ArgumentError && '$e'.contains(substring));
 
-    expect(() => op(receiver, null), throwsArgumentErrorMentioning('null'));
+    expect(
+        () => op(receiver, null),
+        throwsA(isA<TypeError>().having(
+            (e) => e.toString(), 'should mention Null', contains('Null'))));
     expect(() => op(receiver, 'foo'), throwsArgumentErrorMentioning(r'"foo"'));
   }
 
@@ -457,7 +460,6 @@ void main() {
       expect(n1 & n2, Int64(1168));
       expect(n3 & n2, Int64(8708));
       expect(n4 & n5, Int64(0x1034) << 32);
-      expect(() => n1 & null, throwsArgumentError);
       argumentErrorTest('&', (a, b) => a & b);
     });
 
@@ -465,7 +467,6 @@ void main() {
       expect(n1 | n2, Int64(9942));
       expect(n3 | n2, Int64(-66));
       expect(n4 | n5, Int64(0x9a76) << 32);
-      expect(() => n1 | null, throwsArgumentError);
       argumentErrorTest('|', (a, b) => a | b);
     });
 
@@ -473,7 +474,6 @@ void main() {
       expect(n1 ^ n2, Int64(8774));
       expect(n3 ^ n2, Int64(-8774));
       expect(n4 ^ n5, Int64(0x8a42) << 32);
-      expect(() => n1 ^ null, throwsArgumentError);
       argumentErrorTest('^', (a, b) => a ^ b);
     });
 
@@ -501,7 +501,6 @@ void main() {
       expect(Int64(42) << 64, Int64.ZERO);
       expect(Int64(42) << 65, Int64.ZERO);
       expect(() => Int64(17) << -1, throwsArgumentError);
-      expect(() => Int64(17) << null, throwsNoSuchMethodError);
     });
 
     test('>>', () {
@@ -553,7 +552,6 @@ void main() {
       expect(Int64.fromInts(0x92345678, 0x9abcdef0) >> 48,
           Int64.fromInts(0xffffffff, 0xffff9234));
       expect(() => Int64(17) >> -1, throwsArgumentError);
-      expect(() => Int64(17) >> null, throwsNoSuchMethodError);
     });
 
     test('shiftRightUnsigned', () {
@@ -600,7 +598,6 @@ void main() {
       expect(Int64(-1).shiftRightUnsigned(64), Int64.ZERO);
       expect(Int64(1).shiftRightUnsigned(64), Int64.ZERO);
       expect(() => Int64(17).shiftRightUnsigned(-1), throwsArgumentError);
-      expect(() => Int64(17).shiftRightUnsigned(null), throwsNoSuchMethodError);
     });
 
     test('overflow', () {


### PR DESCRIPTION
Primarily this is just removing a bunch of dynamic params and converting them to Object, and then removing some of the explicit tests around null args that are no longer valid statically in the test.

Note that the runtime argument errors are still present, and I left the tests in for `argumentErrorTest`  which effectively validates the non-opted in users calling these functions still get the same behavior.

We could restore some of the other tests that I deleted to do a similar thing, if we think its worth while.