### PR TITLE
Remove unnecessary casts from remainder computations.

### DIFF
--- a/test/int32_test.dart
+++ b/test/int32_test.dart
@@ -110,15 +110,15 @@ void main() {
 
     test('remainder', () {
       expect(Int32(0x12345678).remainder(Int32(0x22)),
-          Int32(0x12345678.remainder(0x22) as int));
+          Int32(0x12345678.remainder(0x22)));
       expect(Int32(0x12345678).remainder(Int32(-0x22)),
-          Int32(0x12345678.remainder(-0x22) as int));
+          Int32(0x12345678.remainder(-0x22)));
       expect(Int32(-0x12345678).remainder(Int32(-0x22)),
-          Int32(-0x12345678.remainder(-0x22) as int));
+          Int32(-0x12345678.remainder(-0x22)));
       expect(Int32(-0x12345678).remainder(Int32(0x22)),
-          Int32(-0x12345678.remainder(0x22) as int));
+          Int32(-0x12345678.remainder(0x22)));
       expect(Int32(0x12345678).remainder(Int64(0x22)),
-          Int32(0x12345678.remainder(0x22) as int));
+          Int32(0x12345678.remainder(0x22)));
     });
 
     test('abs', () {


### PR DESCRIPTION
Now that the analyzer correctly computes the type of
`int.remainder(int)` as `int` (for libraries opted into null safety),
we no longer need to cast the result to an `int`.