### PR TITLE
remove some unnecessary casts from tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.0.0-nullsafety.1-dev
+
 ## 1.0.0-nullsafety
 
 * Migrate to null safety.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fixnum
-version: 1.0.0-nullsafety
+version: 1.0.0-nullsafety.1-dev
 
 description: >-
   Library for 32- and 64-bit signed fixed-width integers with consistent

--- a/test/int32_test.dart
+++ b/test/int32_test.dart
@@ -110,15 +110,15 @@ void main() {
 
     test('remainder', () {
       expect(Int32(0x12345678).remainder(Int32(0x22)),
-          Int32(0x12345678.remainder(0x22) as int));
+          Int32(0x12345678.remainder(0x22)));
       expect(Int32(0x12345678).remainder(Int32(-0x22)),
-          Int32(0x12345678.remainder(-0x22) as int));
+          Int32(0x12345678.remainder(-0x22)));
       expect(Int32(-0x12345678).remainder(Int32(-0x22)),
-          Int32(-0x12345678.remainder(-0x22) as int));
+          Int32(-0x12345678.remainder(-0x22)));
       expect(Int32(-0x12345678).remainder(Int32(0x22)),
-          Int32(-0x12345678.remainder(0x22) as int));
+          Int32(-0x12345678.remainder(0x22)));
       expect(Int32(0x12345678).remainder(Int64(0x22)),
-          Int32(0x12345678.remainder(0x22) as int));
+          Int32(0x12345678.remainder(0x22)));
     });
 
     test('abs', () {

--- a/test/int64_test.dart
+++ b/test/int64_test.dart
@@ -272,15 +272,15 @@ void main() {
       expect(Int64.MAX_VALUE % Int64.fromInts(0x04000000, 0x00000000),
           Int64.fromInts(0x3ffffff, 0xffffffff));
       expect(Int64(0x12345678).remainder(Int64(0x22)),
-          Int64(0x12345678.remainder(0x22) as int));
+          Int64(0x12345678.remainder(0x22)));
       expect(Int64(0x12345678).remainder(Int64(-0x22)),
-          Int64(0x12345678.remainder(-0x22) as int));
+          Int64(0x12345678.remainder(-0x22)));
       expect(Int64(-0x12345678).remainder(Int64(-0x22)),
-          Int64(-0x12345678.remainder(-0x22) as int));
+          Int64(-0x12345678.remainder(-0x22)));
       expect(Int64(-0x12345678).remainder(Int64(0x22)),
-          Int64(-0x12345678.remainder(0x22) as int));
+          Int64(-0x12345678.remainder(0x22)));
       expect(Int32(0x12345678).remainder(Int64(0x22)),
-          Int64(0x12345678.remainder(0x22) as int));
+          Int64(0x12345678.remainder(0x22)));
       argumentErrorTest('%', (a, b) => a % b);
     });
 


### PR DESCRIPTION
This was recently fixed in the analyzer