### PR TITLE
Add Int64.toBytesBigEndian()

### DIFF
--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -643,6 +643,19 @@ class Int64 implements IntX {
     return result;
   }
 
+  List<int> toBytesBigEndian() {
+    var result = List<int>.filled(8, 0);
+    result[7] = _l & 0xff;
+    result[6] = (_l >> 8) & 0xff;
+    result[5] = ((_m << 6) & 0xfc) | ((_l >> 16) & 0x3f);
+    result[4] = (_m >> 2) & 0xff;
+    result[3] = (_m >> 10) & 0xff;
+    result[2] = ((_h << 4) & 0xf0) | ((_m >> 18) & 0xf);
+    result[1] = (_h >> 4) & 0xff;
+    result[0] = (_h >> 12) & 0xff;
+    return result;
+  }
+
   @override
   double toDouble() => toInt().toDouble();
 

--- a/test/int64_test.dart
+++ b/test/int64_test.dart
@@ -713,6 +713,16 @@ void main() {
       expect(Int64(-1).toBytes(),
           [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
     });
+
+    test('toBytesBigEndian', () {
+      expect(Int64(0).toBytesBigEndian(), [0, 0, 0, 0, 0, 0, 0, 0]);
+      expect(Int64.fromInts(0x08070605, 0x04030201).toBytesBigEndian(),
+          [8, 7, 6, 5, 4, 3, 2, 1]);
+      expect(Int64.fromInts(0x01020304, 0x05060708).toBytesBigEndian(),
+          [1, 2, 3, 4, 5, 6, 7, 8]);
+      expect(Int64(-1).toBytesBigEndian(),
+          [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+    });
   });
 
   test('JavaScript 53-bit integer boundary', () {


### PR DESCRIPTION
This commit adds Int64.toBytesBigEndian() so that Int64.toBytes() is
symmetric to Int64.fromBytes() and Int64.fromBytesBigEndian().