### PR TITLE
Migrate deprecated List constructor to List.filled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.10.12-dev
+
 ## 0.10.11
 
 * Update minimum SDK constraint to version 2.1.1.

--- a/lib/src/int32.dart
+++ b/lib/src/int32.dart
@@ -386,7 +386,7 @@ class Int32 implements IntX {
 
   @override
   List<int> toBytes() {
-    var result = List<int>(4);
+    var result = List<int>.filled(4, 0);
     result[0] = _i & 0xff;
     result[1] = (_i >> 8) & 0xff;
     result[2] = (_i >> 16) & 0xff;

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -631,7 +631,7 @@ class Int64 implements IntX {
 
   @override
   List<int> toBytes() {
-    List<int> result = List<int>(8);
+    List<int> result = List<int>.filled(8, 0);
     result[0] = _l & 0xff;
     result[1] = (_l >> 8) & 0xff;
     result[2] = ((_m << 6) & 0xfc) | ((_l >> 16) & 0x3f);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,6 @@ name: fixnum
 version: 0.10.12-dev
 
 description: Library for 32- and 64-bit signed fixed-width integers.
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/fixnum
 
 environment:


### PR DESCRIPTION
Closes #79 

Use `List.filled` to continue making fixed sized lists.

Remove deprecated author field from the pubspec.