### PR TITLE
Move from pedantic to lints package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.0.1-dev
+
 ## 1.0.0
 
 * Stable null safety release.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 analyzer:
   strong-mode:
     implicit-casts: false

--- a/lib/src/int32.dart
+++ b/lib/src/int32.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: constant_identifier_names
+
 part of fixnum;
 
 /// An immutable 32-bit signed integer, in the range [-2^31, 2^31 - 1].

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: constant_identifier_names
+
 // Many locals are declared as `int` or `double`. We keep local variable types
 // because the types are critical to the efficiency of many operations.
 //

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fixnum
-version: 1.0.0
+version: 1.0.1-dev
 
 description: >-
   Library for 32- and 64-bit signed fixed-width integers with consistent
@@ -7,8 +7,8 @@ description: >-
 homepage: https://github.com/dart-lang/fixnum
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  pedantic: ^1.10.0
-  test: ^1.16.0-nullsafety
+  lints: ^1.0.0
+  test: ^1.16.0


### PR DESCRIPTION
Ignore the `constant_identifier_names` lint to avoid
breaking changes to the API.