### PR TITLE
prep for publishing 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 1.0.1-dev
+## 1.0.1
+
+* Switch to using `package:lints`.
+* Populate the pubspec `repository` field.
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-A fixed-width 32- and 64- bit integer library for Dart.
-
+[![Dart CI](https://github.com/dart-lang/fixnum/actions/workflows/test-package.yml/badge.svg)](https://github.com/dart-lang/fixnum/actions/workflows/test-package.yml)
 [![Pub](https://img.shields.io/pub/v/fixnum.svg)](https://pub.dev/packages/fixnum)
-[![Dart CI](https://github.com/dart-lang/fixnum/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/fixnum/actions?query=workflow%3A%22Dart+CI%22+branch%3Amaster)
-[![Coverage Status](https://img.shields.io/coveralls/dart-lang/fixnum.svg)](https://coveralls.io/r/dart-lang/fixnum)
+[![package publisher](https://img.shields.io/pub/publisher/fixnum.svg)](https://pub.dev/packages/fixnum/publisher)
+
+A fixed-width 32- and 64- bit integer library for Dart.
 
 Provides data types for signed 32- and 64-bit integers.
 The integer implementations in this library are designed to work identically

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,5 @@
 include: package:lints/recommended.yaml
+
 analyzer:
   strong-mode:
     implicit-casts: false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fixnum
-version: 1.0.1-dev
+version: 1.0.1
 description: >-
   Library for 32- and 64-bit signed fixed-width integers with consistent
   behavior between native and JS runtimes.


### PR DESCRIPTION
prep for publishing 1.0.1:
- rev the version
- update the changelog
- update the markdown badges in the readme