### PR TITLE
Remove old language version markers

### DIFF
--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,9 +1,6 @@
 // Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-//
-// TODO: Remove https://github.com/dart-lang/sdk/issues/43605
-// @dart=2.11
 
 import 'int32_test.dart' as int32_test;
 import 'int64_test.dart' as int64_test;


### PR DESCRIPTION
Looks like this is no longer needed?