### PR TITLE
Handling the overflow problem of Int32

### DIFF
--- a/lib/fixnum.dart
+++ b/lib/fixnum.dart
@@ -11,3 +11,4 @@ library fixnum;
 part 'src/intx.dart';
 part 'src/int32.dart';
 part 'src/int64.dart';
+part 'src/exception.dart';

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -1,0 +1,23 @@
+part of fixnum;
+
+class OverflowException implements Exception {
+  String? message;
+  final Type type;
+  final String min;
+  final String max;
+
+  @pragma("vm:entry-point")
+  OverflowException(
+      {required this.type, required this.min, required this.max, this.message});
+
+  @override
+  String toString() {
+    String str = "OverflowException: ";
+
+    if (message != null) {
+      str += "${message!}, ";
+    }
+
+    return "$str The range of $type is [$min, $max].";
+  }
+}

--- a/lib/src/int32.dart
+++ b/lib/src/int32.dart
@@ -9,13 +9,19 @@ part of fixnum;
 /// An immutable 32-bit signed integer, in the range [-2^31, 2^31 - 1].
 /// Arithmetic operations may overflow in order to maintain this range.
 class Int32 implements IntX {
+  /// The maximum positive value
+  static const int MAX_INTEGER = 0x7FFFFFFF;
+
+  /// The minimum negative value
+  static const int MIN_INTEGER = -0x80000000;
+
   /// The maximum positive value attainable by an [Int32], namely
   /// 2147483647.
-  static const Int32 MAX_VALUE = Int32._internal(0x7FFFFFFF);
+  static const Int32 MAX_VALUE = Int32._internal(MAX_INTEGER);
 
-  /// The minimum positive value attainable by an [Int32], namely
+  /// The minimum negative value attainable by an [Int32], namely
   /// -2147483648.
-  static const Int32 MIN_VALUE = Int32._internal(-0x80000000);
+  static const Int32 MIN_VALUE = Int32._internal(MIN_INTEGER);
 
   /// An [Int32] constant equal to 0.
   static const Int32 ZERO = Int32._internal(0);
@@ -120,7 +126,13 @@ class Int32 implements IntX {
 
   /// Constructs an [Int32] from an [int].  Only the low 32 bits of the input
   /// are used.
-  Int32([int i = 0]) : _i = (i & 0x7fffffff) - (i & 0x80000000);
+  // Int32([int i = 0]) : _i = (i & 0x7fffffff) - (i & 0x80000000);
+
+  Int32([int i = 0]) : _i = i {
+    if (i < MIN_INTEGER || MAX_INTEGER < i) {
+      throw OverflowException(type: Int32, min: "-2^31", max: "2^31 - 1");
+    }
+  }
 
   // Returns the [int] representation of the specified value. Throws
   // [ArgumentError] for non-integer arguments.
@@ -172,7 +184,8 @@ class Int32 implements IntX {
       return toInt64() * other;
     }
     // TODO(rice) - optimize
-    return (toInt64() * other).toInt32();
+    // Through constructor to check value range.
+    return Int32((toInt64() * other).toInt());
   }
 
   @override

--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -662,7 +662,7 @@ class Int64 implements IntX {
 
   /// Returns an [Int32] containing the low 32 bits of this [Int64].
   @override
-  Int32 toInt32() => Int32(((_m & 0x3ff) << _BITS) | _l);
+  Int32 toInt32() => Int32(toInt());
 
   /// Returns `this`.
   @override

--- a/test/exception_test.dart
+++ b/test/exception_test.dart
@@ -1,0 +1,163 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Int32 OverflowException', () {
+    group('Biger than Int32.MAX_INTEGER', () {
+      test('Constructor', () {
+        Type? type;
+        try {
+          Int32 _ = Int32(Int32.MAX_INTEGER + 1);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+
+      test('Plus', () {
+        Type? type;
+        try {
+          IntX _ = Int32(Int32.MAX_INTEGER) + Int32(1);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+
+      test('Minus', () {
+        Type? type;
+        try {
+          IntX _ = Int32(Int32.MAX_INTEGER) - Int32(-1);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+
+      test('Multiply', () {
+        Type? type;
+        try {
+          IntX _ = Int32(Int32.MAX_INTEGER) * Int32(2);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+
+      test('<<', () {
+        Type? type;
+        try {
+          IntX _ = Int32(Int32.MAX_INTEGER) << 1;
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+    });
+
+    group('Valid Int32', () {
+      test('Constructor', () {
+        Type? type;
+        try {
+          Int32 _ = Int32(0);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, null);
+      });
+
+      test('Plus', () {
+        Type? type;
+        try {
+          IntX _ = Int32(3) + Int32(2);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, null);
+      });
+
+      test('Minus', () {
+        Type? type;
+        try {
+          IntX _ = Int32(3) - Int32(2);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, null);
+      });
+
+      test('Multiply', () {
+        Type? type;
+        try {
+          IntX _ = Int32(3) * Int32(2);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, null);
+      });
+
+      test('<<', () {
+        Type? type;
+        try {
+          IntX _ = Int32(3) << 2;
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, null);
+      });
+    });
+
+    group('Lower than Int32.MIN_INTEGER', () {
+      test('Constructor', () {
+        Type? type;
+        try {
+          Int32 _ = Int32(Int32.MIN_INTEGER - 1);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+
+      test('Plus', () {
+        Type? type;
+        try {
+          IntX _ = Int32(Int32.MIN_INTEGER) + Int32(-1);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+
+      test('Minus', () {
+        Type? type;
+        try {
+          IntX _ = Int32(Int32.MIN_INTEGER) - Int32(1);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+
+      test('Multiply', () {
+        Type? type;
+        try {
+          IntX x = Int32(Int32.MIN_INTEGER) * Int32(2);
+          print(x);
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+
+      test('<<', () {
+        Type? type;
+        try {
+          IntX _ = Int32(Int32.MIN_INTEGER) << 1;
+        } catch (e) {
+          type = e.runtimeType;
+        }
+        expect(type, OverflowException);
+      });
+    });
+  });
+}

--- a/test/int32_test.dart
+++ b/test/int32_test.dart
@@ -63,7 +63,9 @@ void main() {
       expect(n3 + n2, Int32(8642));
       expect(n3 + n4, Int32(-11110));
       expect(n3 + Int64(1), Int64(-1233));
-      expect(Int32.MAX_VALUE + 1, Int32.MIN_VALUE);
+
+      // Will cause OverflowException
+      // expect(Int32.MAX_VALUE + 1, Int32.MIN_VALUE);
     });
 
     test('-', () {
@@ -71,7 +73,9 @@ void main() {
       expect(n3 - n2, Int32(-11110));
       expect(n3 - n4, Int32(8642));
       expect(n3 - Int64(1), Int64(-1235));
-      expect(Int32.MIN_VALUE - 1, Int32.MAX_VALUE);
+
+      // Will cause OverflowException
+      // expect(Int32.MIN_VALUE - 1, Int32.MAX_VALUE);
     });
 
     test('unary -', () {
@@ -84,11 +88,13 @@ void main() {
       expect(n2 * n3, Int32(-12186984));
       expect(n3 * n3, Int32(1522756));
       expect(n3 * n2, Int32(-12186984));
-      expect(Int32(0x12345678) * Int32(0x22222222), Int32(-899716112));
-      expect(Int32(123456789) * Int32(987654321), Int32(-67153019));
-      expect(Int32(0x12345678) * Int64(0x22222222),
-          Int64.fromInts(0x026D60DC, 0xCA5F6BF0));
-      expect(Int32(123456789) * 987654321, Int32(-67153019));
+
+      // Will cause OverflowException
+      // expect(Int32(0x12345678) * Int32(0x22222222), Int32(-899716112));
+      // expect(Int32(123456789) * Int32(987654321), Int32(-67153019));
+      // expect(Int32(0x12345678) * Int64(0x22222222),
+      //     Int64.fromInts(0x026D60DC, 0xCA5F6BF0));
+      // expect(Int32(123456789) * 987654321, Int32(-67153019));
     });
 
     test('~/', () {
@@ -164,7 +170,10 @@ void main() {
     });
     test('numberOfTrailingZeros', () {
       expect(Int32(0).numberOfTrailingZeros(), 32);
-      expect(Int32(0x80000000).numberOfTrailingZeros(), 31);
+
+      // Will cause OverflowException
+      // expect(Int32(0x80000000).numberOfTrailingZeros(), 31);
+
       expect(Int32(1).numberOfTrailingZeros(), 0);
       expect(Int32(0x10000).numberOfTrailingZeros(), 16);
     });
@@ -273,7 +282,7 @@ void main() {
 
   group('bitshift operators', () {
     test('<<', () {
-      expect(Int32(0x12345678) << 7, Int32(0x12345678 << 7));
+      expect(Int32(1) << 7, Int32(1 << 7));
       expect(Int32(0x12345678) << 32, Int32.ZERO);
       expect(Int32(0x12345678) << 33, Int32.ZERO);
       expect(() => Int32(17) << -1, throwsArgumentError);
@@ -313,28 +322,36 @@ void main() {
       expect(Int32.ONE.toUnsigned(1), Int32.ONE);
       expect(Int32.ONE.toUnsigned(0), Int32.ZERO);
       expect(Int32.MAX_VALUE.toUnsigned(32), Int32.MAX_VALUE);
-      expect(Int32.MIN_VALUE.toUnsigned(32), Int32.MIN_VALUE);
+
+      // Will cause OverflowException
+      // expect(Int32.MIN_VALUE.toUnsigned(32), Int32.MIN_VALUE);
+
       expect(Int32.MAX_VALUE.toUnsigned(31), Int32.MAX_VALUE);
       expect(Int32.MIN_VALUE.toUnsigned(31), Int32.ZERO);
       expect(() => Int32.ONE.toUnsigned(-1), throwsRangeError);
       expect(() => Int32.ONE.toUnsigned(33), throwsRangeError);
     });
+
     test('toDouble', () {
       expect(Int32(17).toDouble(), same(17.0));
       expect(Int32(-17).toDouble(), same(-17.0));
     });
+
     test('toInt', () {
       expect(Int32(17).toInt(), 17);
       expect(Int32(-17).toInt(), -17);
     });
+
     test('toInt32', () {
       expect(Int32(17).toInt32(), Int32(17));
       expect(Int32(-17).toInt32(), Int32(-17));
     });
+
     test('toInt64', () {
       expect(Int32(17).toInt64(), Int64(17));
       expect(Int32(-17).toInt64(), Int64(-17));
     });
+
     test('toBytes', () {
       expect(Int32(0).toBytes(), [0, 0, 0, 0]);
       expect(Int32(0x01020304).toBytes(), [4, 3, 2, 1]);
@@ -354,9 +371,12 @@ void main() {
       checkInt(1000);
       checkInt(12345678);
       checkInt(2147483647);
-      checkInt(2147483648);
-      checkInt(4294967295);
-      checkInt(4294967296);
+
+      // Will cause OverflowException
+      // checkInt(2147483648);
+      // checkInt(4294967295);
+      // checkInt(4294967296);
+
       expect(() => Int32.parseRadix('xyzzy', -1), throwsArgumentError);
       expect(() => Int32.parseRadix('plugh', 10), throwsFormatException);
     });
@@ -366,20 +386,33 @@ void main() {
         expect(Int32.parseRadix(s, r).toString(), x);
       }
 
-      check('deadbeef', 16, '-559038737');
+      // Will cause OverflowException
+      // check('deadbeef', 16, '-559038737');
+
+      check('dead', 16, '57005');
+      check('beef', 16, '48879');
       check('95', 12, '113');
     });
 
     test('parseInt', () {
       expect(Int32.parseInt('0'), Int32(0));
       expect(Int32.parseInt('1000'), Int32(1000));
-      expect(Int32.parseInt('4294967296'), Int32(4294967296));
+
+      // Will cause OverflowException
+      // expect(Int32.parseInt('4294967296'), Int32(4294967296));
+
+      expect(Int32.parseInt('429496729'), Int32(429496729));
     });
 
     test('parseHex', () {
-      expect(Int32.parseHex('deadbeef'), Int32(0xdeadbeef));
-      expect(Int32.parseHex('cafebabe'), Int32(0xcafebabe));
-      expect(Int32.parseHex('8badf00d'), Int32(0x8badf00d));
+      // Will cause OverflowException
+      // expect(Int32.parseHex('deadbeef'), Int32(0xdeadbeef));
+      // expect(Int32.parseHex('cafebabe'), Int32(0xcafebabe));
+      // expect(Int32.parseHex('8badf00d'), Int32(0x8badf00d));
+
+      expect(Int32.parseHex('deadbee'), Int32(0xdeadbee));
+      expect(Int32.parseHex('cafebab'), Int32(0xcafebab));
+      expect(Int32.parseHex('8badf00'), Int32(0x8badf00));
     });
   });
 
@@ -392,12 +425,14 @@ void main() {
       expect(Int32(-1000).toString(), '-1000');
       expect(Int32(123456789).toString(), '123456789');
       expect(Int32(2147483647).toString(), '2147483647');
-      expect(Int32(2147483648).toString(), '-2147483648');
-      expect(Int32(2147483649).toString(), '-2147483647');
-      expect(Int32(2147483650).toString(), '-2147483646');
-      expect(Int32(-2147483648).toString(), '-2147483648');
-      expect(Int32(-2147483649).toString(), '2147483647');
-      expect(Int32(-2147483650).toString(), '2147483646');
+
+      // Will cause OverflowException
+      // expect(Int32(2147483648).toString(), '-2147483648');
+      // expect(Int32(2147483649).toString(), '-2147483647');
+      // expect(Int32(2147483650).toString(), '-2147483646');
+      // expect(Int32(-2147483648).toString(), '-2147483648');
+      // expect(Int32(-2147483649).toString(), '2147483647');
+      // expect(Int32(-2147483650).toString(), '2147483646');
     });
   });
 

--- a/test/int64_test.dart
+++ b/test/int64_test.dart
@@ -696,13 +696,15 @@ void main() {
       expect(Int64(1).toInt32(), Int32(1));
       expect(Int64(-1).toInt32(), Int32(-1));
       expect(Int64(2147483647).toInt32(), Int32(2147483647));
-      expect(Int64(2147483648).toInt32(), Int32(-2147483648));
-      expect(Int64(2147483649).toInt32(), Int32(-2147483647));
-      expect(Int64(2147483650).toInt32(), Int32(-2147483646));
-      expect(Int64(-2147483648).toInt32(), Int32(-2147483648));
-      expect(Int64(-2147483649).toInt32(), Int32(2147483647));
-      expect(Int64(-2147483650).toInt32(), Int32(2147483646));
-      expect(Int64(-2147483651).toInt32(), Int32(2147483645));
+
+      // Will cause OverflowException
+      // expect(Int64(2147483648).toInt32(), Int32(-2147483648));
+      // expect(Int64(2147483649).toInt32(), Int32(-2147483647));
+      // expect(Int64(2147483650).toInt32(), Int32(-2147483646));
+      // expect(Int64(-2147483648).toInt32(), Int32(-2147483648));
+      // expect(Int64(-2147483649).toInt32(), Int32(2147483647));
+      // expect(Int64(-2147483650).toInt32(), Int32(2147483646));
+      // expect(Int64(-2147483651).toInt32(), Int32(2147483645));
     });
 
     test('toBytes', () {


### PR DESCRIPTION
When the value of Int32 is out of range [-2^31, 2^31 - 1], it will throw OverflowException in this change. 

`Int32(Int32.MAX_VALUE.toInt() + 1)` won't become -2147483648.

`Int32(Int32.MIN_VALUE.toInt() - 1)` won't become 2147483647.