### PR TITLE
rev the sdk min to 2.19.0-0

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,8 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.12.0, dev]
+        # TODO(devoncarew): Add `2.19.0` to this once that release is stable
+        sdk: [dev]
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0
+## 1.1.0-dev
 
 * Add `tryParseRadix`, `tryParseInt` and `tryParseHex` static methods
   to both `Int32` and `Int64`.
@@ -6,6 +6,8 @@
   and of `toHexString`.
 * Make `Int32` parse functions consistent with documentation (accept
   leading minus sign, do not accept empty inputs).
+* Update the minimum SDK constraint to 2.19.
+
 ## 1.0.1
 
 * Switch to using `package:lints`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 repository: https://github.com/dart-lang/fixnum
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.19.0-0 <3.0.0'
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
- rev the sdk min to 2.19.0-0

This latest version of this package won't analyze cleanly for users (wrt the `unrelated_type_equality_checks` lint) without a fix for that lint in the `2.19.0` sdk. See also https://github.com/dart-lang/fixnum/pull/97.
