### PR TITLE
Update numberOf{Leading,Trailing}Zeros documentation

### DIFF
--- a/lib/src/int64.dart
+++ b/lib/src/int64.dart
@@ -634,8 +634,6 @@ class Int64 implements IntX {
     return this;
   }
 
-  /// Returns the number of leading zeros in this [Int64] as an [int]
-  /// between 0 and 64.
   @override
   int numberOfLeadingZeros() {
     int b2 = u.numberOfLeadingZeros(_h);
@@ -651,8 +649,6 @@ class Int64 implements IntX {
     }
   }
 
-  /// Returns the number of trailing zeros in this [Int64] as an [int]
-  /// between 0 and 64.
   @override
   int numberOfTrailingZeros() {
     int zeros = u.numberOfTrailingZeros(_l);

--- a/lib/src/intx.dart
+++ b/lib/src/intx.dart
@@ -125,12 +125,18 @@ abstract class IntX implements Comparable<Object> {
   /// value, add one, i.e. use `x.bitLength + 1`.
   int get bitLength;
 
-  /// Returns the number of high-order zeros in this integer's bit
-  /// representation.
+  /// Returns the number of leading (most significant) zeros in this integer's
+  /// two's complement representation.
+  ///
+  /// For zero, the result is the same as the integer type's bit max. bit
+  /// length.
   int numberOfLeadingZeros();
 
-  /// Returns the number of low-order zeros in this integer's bit
-  /// representation.
+  /// Returns the number of trailing (least significant) zeros in this
+  /// integer's two's complement representation.
+  ///
+  /// For zero, the result is the same as the integer type's bit max. bit
+  /// length.
   int numberOfTrailingZeros();
 
   /// Returns the least significant [width] bits of this integer, extending the


### PR DESCRIPTION
- Mention the result when the integer is 0.
- Clarify that leading = most significant, trailing = least significant.
- Remove the documentation from the implementation class.